### PR TITLE
fix: add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+*.log


### PR DESCRIPTION
based on https://github.com/github/gitignore/blob/main/Go.gitignore

This will also ensure `debug.log` doesn't get persisted to source control