### PR TITLE
chore: setup initial CI to validate builds (tests later)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+name: Go
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.x'
+      - name: Install dependencies
+        run: go get .
+      - name: Build
+        run: go build -v ./...
+      # once we have tests we can uncomment.  For now, we'll just build
+      # - name: Test with the Go CLI
+      #   run: go test

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/tomgeorge/todoist-tui/pkg/cache"
@@ -299,7 +300,7 @@ func RenderTask(task types.Task) string {
 	out += "Created At: " + task.CreatedAt + "\n"
 	out += "Assignee ID: " + task.AssigneeId + "\n"
 	out += "Assigner ID: " + task.AssignerId + "\n"
-	out += "Comment Count: " + string(task.CommentCount) + "\n"
+	out += "Comment Count: " + strconv.Itoa(task.CommentCount) + "\n"
 	out += fmt.Sprintf("Is Completed? %v\n", task.IsCompleted)
 	out += "Content: " + task.Content + "\n"
 	out += "Description: " + task.Description + "\n"
@@ -307,8 +308,8 @@ func RenderTask(task types.Task) string {
 	out += " Duration: " + task.Duration + "\n"
 	out += "ID: " + task.Id + "\n"
 	out += fmt.Sprintf("Labels: %v\n", task.Labels)
-	out += "Order: " + string(task.Order) + "\n"
-	out += "Priority: " + string(task.Priority) + "\n"
+	out += "Order: " + strconv.Itoa(task.Order) + "\n"
+	out += "Priority: " + strconv.Itoa(task.Priority) + "\n"
 	out += "Project ID: " + task.ProjectId + "\n"
 	out += "Section ID: " + task.SectionId + "\n"
 	out += "Parent ID: " + task.ParentId + "\n"


### PR DESCRIPTION
- [x] fix one thing in main about int to string

Error was receiving was:

```
./main.go:302:29: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
./main.go:310:21: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
./main.go:311:24: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```

Example playground (press run) https://go.dev/play/p/mzctuTQaXy9?v=goprev